### PR TITLE
Switch SQS polling interval to millisecond resolution

### DIFF
--- a/sql-streaming-sqs/README.md
+++ b/sql-streaming-sqs/README.md
@@ -47,23 +47,23 @@ This library is compiled for Scala 2.12 only, and intends to support Spark 2.4.0
 ## Configuration options
 The configuration is obtained from parameters.
 
-Name |Default | Meaning
---- |:---:| ---
-sqsUrl|required, no default value|sqs queue url, like 'https://sqs.us-east-1.amazonaws.com/330183209093/TestQueue'
-region|required, no default value|AWS region where queue is created
-fileFormat|required, no default value|file format for the s3 files stored on Amazon S3
-schema|required, no default value|schema of the data being read
-sqsFetchIntervalSeconds|10|time interval (in seconds) after which to fetch messages from Amazon SQS queue
-sqsLongPollingWaitTimeSeconds|20|wait time (in seconds) for long polling on Amazon SQS queue
-sqsMaxConnections|1|number of parallel threads to connect to Amazon SQS queue
-sqsMaxRetries|10|Maximum number of consecutive retries in case of a connection failure to SQS before giving up
-ignoreFileDeletion|false|whether to ignore any File deleted message in SQS queue
-fileNameOnly|false|Whether to check new files based on only the filename instead of on the full path
-shouldSortFiles|true|whether to sort files based on timestamp while listing them from SQS
-useInstanceProfileCredentials|false|Whether to use EC2 instance profile credentials for connecting to Amazon SQS
-maxFilesPerTrigger|no default value|maximum number of files to process in a microbatch
-maxFileAge|7d|Maximum age of a file that can be found in this directory
-messageWrapper|None| - 'None' if SQS contains plain S3 message. <br/> - 'SNS' if SQS contains S3 notification message which came from SNS. <br/> Please see 'Use multiple consumers' section for more details 
+Name |          Default           | Meaning
+--- |:--------------------------:| ---
+sqsUrl| required, no default value |sqs queue url, like 'https://sqs.us-east-1.amazonaws.com/330183209093/TestQueue'
+region| required, no default value |AWS region where queue is created
+fileFormat| required, no default value |file format for the s3 files stored on Amazon S3
+schema| required, no default value |schema of the data being read
+sqsFetchIntervalMilliseconds|            1000            |time interval (in milliseconds) after which to fetch messages from Amazon SQS queue
+sqsLongPollingWaitTimeSeconds|             20             |wait time (in seconds) for long polling on Amazon SQS queue
+sqsMaxConnections|             1              |number of parallel threads to connect to Amazon SQS queue
+sqsMaxRetries|             10             |Maximum number of consecutive retries in case of a connection failure to SQS before giving up
+ignoreFileDeletion|           false            |whether to ignore any File deleted message in SQS queue
+fileNameOnly|           false            |Whether to check new files based on only the filename instead of on the full path
+shouldSortFiles|            true            |whether to sort files based on timestamp while listing them from SQS
+useInstanceProfileCredentials|           false            |Whether to use EC2 instance profile credentials for connecting to Amazon SQS
+maxFilesPerTrigger|      no default value      |maximum number of files to process in a microbatch
+maxFileAge|             7d             |Maximum age of a file that can be found in this directory
+messageWrapper|            None            | - 'None' if SQS contains plain S3 message. <br/> - 'SNS' if SQS contains S3 notification message which came from SNS. <br/> Please see 'Use multiple consumers' section for more details 
 
 ## Use multiple consumers
 
@@ -86,7 +86,7 @@ An example to create a SQL stream which uses Amazon SQS to list files on S3,
                           .schema(schema)
                           .option("sqsUrl", queueUrl)
                           .option("fileFormat", "json")
-                          .option("sqsFetchIntervalSeconds", "2")
+                          .option("sqsFetchIntervalMilliseconds", "2000")
                           .option("sqsLongPollingWaitTimeSeconds", "5")
                           .option("useInstanceProfileCredentials", "true")
                           .load()

--- a/sql-streaming-sqs/examples/src/main/scala/org/apache/bahir/examples/sql/streaming/sqs/SqsSourceExample.scala
+++ b/sql-streaming-sqs/examples/src/main/scala/org/apache/bahir/examples/sql/streaming/sqs/SqsSourceExample.scala
@@ -51,7 +51,7 @@ object SqsSourceExample {
       .schema(schema)
       .option("sqsUrl", queueUrl)
       .option("fileFormat", fileFormat)
-      .option("sqsFetchIntervalSeconds", "2")
+      .option("sqsFetchIntervalMilliseconds", "2000")
       .option("sqsLongPollingWaitTimeSeconds", "5")
       .option("maxFilesPerTrigger", "50")
       .option("ignoreFileDeletion", "true")

--- a/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsClient.scala
+++ b/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsClient.scala
@@ -209,7 +209,7 @@ class SqsClient(sourceOptions: SqsSourceOptions,
         s"${sqsMaxRetries} times Giving up. Check logs for details."))
     } else {
       logWarning(s"Attempt ${retriesOnFailure}." +
-        s"Will reattempt after ${sqsFetchIntervalSeconds} seconds")
+        s"Will reattempt after ${sqsFetchIntervalMilliseconds} ms")
     }
   }
 

--- a/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsClient.scala
+++ b/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsClient.scala
@@ -40,7 +40,7 @@ import org.apache.spark.util.ThreadUtils
 class SqsClient(sourceOptions: SqsSourceOptions,
                 hadoopConf: Configuration) extends Logging {
 
-  private val sqsFetchIntervalSeconds = sourceOptions.fetchIntervalSeconds
+  private val sqsFetchIntervalMilliseconds = sourceOptions.fetchIntervalMilliseconds
   private val sqsLongPollWaitTimeSeconds = sourceOptions.longPollWaitTimeSeconds
   private val sqsMaxRetries = sourceOptions.maxRetries
   private val maxConnections = sourceOptions.maxConnections
@@ -83,8 +83,8 @@ class SqsClient(sourceOptions: SqsSourceOptions,
   sqsScheduler.scheduleWithFixedDelay(
     sqsFetchMessagesThread,
     0,
-    sqsFetchIntervalSeconds,
-    TimeUnit.SECONDS)
+    sqsFetchIntervalMilliseconds,
+    TimeUnit.MILLISECONDS)
 
   private def sqsFetchMessages(): Seq[(String, Long, String)] = {
     val messageList = try {

--- a/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptions.scala
+++ b/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptions.scala
@@ -60,12 +60,12 @@ class SqsSourceOptions(parameters: CaseInsensitiveMap[String]) extends Logging {
   val maxFileAgeMs: Long =
     Utils.timeStringAsMs(parameters.getOrElse("maxFileAge", "7d"))
 
-  val fetchIntervalSeconds: Int = parameters.get("sqsFetchIntervalSeconds").map { str =>
+  val fetchIntervalMilliseconds: Int = parameters.get("sqsFetchIntervalMillieconds").map { str =>
     Try(str.toInt).toOption.filter(_ > 0).getOrElse {
       throw new IllegalArgumentException(
-        s"Invalid value '$str' for option 'sqsFetchIntervalSeconds', must be a positive integer")
+        s"Invalid value '$str' for option 'sqsFetchIntervalMillieconds', must be a positive integer")
     }
-  }.getOrElse(10)
+  }.getOrElse(1000)
 
   val longPollWaitTimeSeconds: Int = parameters.get("sqsLongPollingWaitTimeSeconds").map { str =>
     Try(str.toInt).toOption.filter(x => x >= 0 && x <= 20).getOrElse {

--- a/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptions.scala
+++ b/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptions.scala
@@ -60,7 +60,7 @@ class SqsSourceOptions(parameters: CaseInsensitiveMap[String]) extends Logging {
   val maxFileAgeMs: Long =
     Utils.timeStringAsMs(parameters.getOrElse("maxFileAge", "7d"))
 
-  val fetchIntervalMilliseconds: Int = parameters.get("sqsFetchIntervalMillieconds").map { str =>
+  val fetchIntervalMilliseconds: Int = parameters.get("sqsFetchIntervalMilliseconds").map { str =>
     Try(str.toInt).toOption.filter(_ > 0).getOrElse {
       throw new IllegalArgumentException(
         s"Invalid value '$str' for option 'sqsFetchIntervalMilliseconds', must be a positive integer")

--- a/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptions.scala
+++ b/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptions.scala
@@ -63,7 +63,7 @@ class SqsSourceOptions(parameters: CaseInsensitiveMap[String]) extends Logging {
   val fetchIntervalMilliseconds: Int = parameters.get("sqsFetchIntervalMillieconds").map { str =>
     Try(str.toInt).toOption.filter(_ > 0).getOrElse {
       throw new IllegalArgumentException(
-        s"Invalid value '$str' for option 'sqsFetchIntervalMillieconds', must be a positive integer")
+        s"Invalid value '$str' for option 'sqsFetchIntervalMilliseconds', must be a positive integer")
     }
   }.getOrElse(1000)
 

--- a/sql-streaming-sqs/src/test/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptionsSuite.scala
+++ b/sql-streaming-sqs/src/test/scala/org/apache/spark/sql/streaming/sqs/SqsSourceOptionsSuite.scala
@@ -58,8 +58,8 @@ class SqsSourceOptionsSuite extends StreamTest {
       }
     }
 
-    testBadOptions("sqsFetchIntervalSeconds" -> "-2")("Invalid value '-2' " +
-      "for option 'sqsFetchIntervalSeconds', must be a positive integer")
+    testBadOptions("sqsFetchIntervalMilliseconds" -> "-2")("Invalid value '-2' " +
+      "for option 'sqsFetchIntervalMilliseconds', must be a positive integer")
     testBadOptions("sqsLongPollingWaitTimeSeconds" -> "-5")("Invalid value '-5' " +
       "for option 'sqsLongPollingWaitTimeSeconds',must be an integer between 0 and 20")
     testBadOptions("sqsMaxConnections" -> "-2")("Invalid value '-2' " +


### PR DESCRIPTION
The intent of this PR is to make the SQS polling interval more fine-grained with millisecond resolution.  With only one spark driver pod (and the `sqsLongPollWaitTimeSeconds` configuration in place) rate limiting shouldn't be a practical concern